### PR TITLE
Fix Terraform apply errors

### DIFF
--- a/main/environments/dev.tfvars
+++ b/main/environments/dev.tfvars
@@ -6,7 +6,7 @@ aws_region            = "us-east-2"
 project_name          = "wyatt-personal-aws"
 domain_name           = "example.com" # Replace with your actual domain name
 app_prefix            = "app-dev"
-cognito_domain_prefix = "wyatt-personal-aws-dev"
+cognito_domain_prefix = "wyatt-personal-dev"
 
 # Network Configuration
 vpc_cidr = "10.0.0.0/16"

--- a/main/modules/frontend/main.tf
+++ b/main/modules/frontend/main.tf
@@ -189,6 +189,11 @@ resource "aws_cloudfront_function" "url_rewrite" {
   name    = "url-rewrite-${substr(sha256(var.bucket_name), 0, 8)}"
   runtime = "cloudfront-js-2.0"
   code    = var.cloudfront_function_code
+
+  # Ensure proper handling of function associations during updates/deletions
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudfront_distribution" "frontend" {

--- a/main/waf.tf
+++ b/main/waf.tf
@@ -6,6 +6,11 @@ resource "aws_wafv2_web_acl" "cloudfront_waf" {
   description = "WAF for CloudFront distribution"
   scope       = "CLOUDFRONT"
 
+  # Ensure proper handling of CloudFront WAF associations during updates/deletions
+  lifecycle {
+    create_before_destroy = true
+  }
+
   default_action {
     allow {}
   }


### PR DESCRIPTION
- Remove reserved word 'aws' from Cognito domain prefix to fix invalid parameter exception
- Add lifecycle create_before_destroy rule to WAFv2 WebACL to handle proper resource disassociation
- Add lifecycle create_before_destroy to CloudFront function to fix deletion issues when in use

🤖 Generated with [Claude Code](https://claude.ai/code)