### PR TITLE
Fix IAM role policy for Cognito unauthenticated users

### DIFF
--- a/main/modules/cognito/main.tf
+++ b/main/modules/cognito/main.tf
@@ -247,24 +247,28 @@ resource "aws_iam_role_policy" "authenticated_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "cognito-sync:*",
-          "cognito-identity:*"
-        ]
-        Resource = "*"
-      },
-      # Add API access permissions
-      {
-        Effect = "Allow"
-        Action = [
-          "execute-api:Invoke"
-        ]
-        Resource = var.api_gateway_arns
-      }
-    ]
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = [
+            "cognito-sync:*",
+            "cognito-identity:*"
+          ]
+          Resource = "*"
+        }
+      ],
+      # Only add API Gateway permissions if ARNs are provided
+      length(var.api_gateway_arns) > 0 ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "execute-api:Invoke"
+          ]
+          Resource = var.api_gateway_arns
+        }
+      ] : []
+    )
   })
 }
 
@@ -307,22 +311,26 @@ resource "aws_iam_role_policy" "unauthenticated_policy" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "cognito-sync:*"
-        ]
-        Resource = "*"
-      },
-      # Add limited public API access if needed
-      {
-        Effect = "Allow"
-        Action = [
-          "execute-api:Invoke"
-        ]
-        Resource = var.public_api_gateway_arns
-      }
-    ]
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Action = [
+            "cognito-sync:*"
+          ]
+          Resource = "*"
+        }
+      ],
+      # Only add API Gateway permissions if ARNs are provided
+      length(var.public_api_gateway_arns) > 0 ? [
+        {
+          Effect = "Allow"
+          Action = [
+            "execute-api:Invoke"
+          ]
+          Resource = var.public_api_gateway_arns
+        }
+      ] : []
+    )
   })
 }

--- a/main/modules/cognito/variables.tf
+++ b/main/modules/cognito/variables.tf
@@ -83,13 +83,13 @@ variable "unauthenticated_role_arn" {
 }
 
 variable "api_gateway_arns" {
-  description = "List of API Gateway ARNs that authenticated users can access"
+  description = "List of API Gateway ARNs that authenticated users can access (use ['*'] for all resources)"
   type        = list(string)
   default     = ["*"]
 }
 
 variable "public_api_gateway_arns" {
-  description = "List of API Gateway ARNs that unauthenticated users can access"
+  description = "List of API Gateway ARNs that unauthenticated users can access (must be specific ARNs, not wildcard)"
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
- Fix MalformedPolicyDocument error by properly handling empty resource lists
- Use concat with conditional statements to handle empty API Gateway ARNs
- Apply same fix to authenticated role policy for consistency
- Update variable descriptions with clearer guidance

This fixes the 'Policy statement must contain resources' error.

🤖 Generated with [Claude Code](https://claude.ai/code)