### PR TITLE
Update GitHub Actions workflow with latest action versions

### DIFF
--- a/.github/workflows/react-tests.yml
+++ b/.github/workflows/react-tests.yml
@@ -21,10 +21,10 @@ jobs:
         working-directory: ./src/frontend/react-app
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
         name: react-app-coverage
 
     - name: Store coverage reports
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: ./src/frontend/react-app/coverage


### PR DESCRIPTION
- Fix actions/upload-artifact from v3 to v4
- Update actions/checkout from v3 to v4 for consistency
- Update actions/setup-node from v3 to v4 for consistency

This resolves the 'Missing download info for actions/upload-artifact@v3' error