### PR TITLE
Implement environment-specific resource naming for multi-workspace deployments

### DIFF
--- a/main/WORKSPACE_NAMING_CHANGES.md
+++ b/main/WORKSPACE_NAMING_CHANGES.md
@@ -1,0 +1,55 @@
+# Workspace Naming Strategy Implementation
+
+## Summary of Changes
+
+This document summarizes the changes made to implement proper workspace naming strategy for multi-environment deployments.
+
+### 1. Lambda Functions (✓ Complete)
+Updated all Lambda function names to include environment variable:
+- `todoist_lambda` → `todoist_lambda_${var.environment}`
+- `ChatGPT_lambda` → `ChatGPT_lambda_${var.environment}`
+- `notion_lambda` → `notion_lambda_${var.environment}`
+- `put_todoist_lambda` → `put_todoist_lambda_${var.environment}`
+- `get_visualization_data` → `get_visualization_data_${var.environment}`
+- `put_visualization_data` → `put_visualization_data_${var.environment}`
+
+Note: Lambda functions in `lambda_visualization.tf` and `lambda_cors.tf` already included environment variables.
+
+### 2. S3 Buckets (✓ Complete)
+Updated S3 bucket names to include environment variable:
+- `step-function-bucket-35315550` → `${var.project_name}-datalake-${var.environment}-35315550`
+- `wyatt-visualization-data-${random_id.bucket_suffix.hex}` → `${var.project_name}-visualization-data-${var.environment}-${random_id.bucket_suffix.hex}`
+- KMS alias: `alias/${var.project_name}-s3-key` → `alias/${var.project_name}-s3-key-${var.environment}`
+
+Note: Frontend bucket already included environment variable.
+
+### 3. DynamoDB Tables (✓ Already Correct)
+All DynamoDB tables already include environment variable:
+- `${var.project_name}-visualizations-${var.environment}`
+- `${var.project_name}-parameters-${var.environment}`
+- `${var.project_name}-parameter-history-${var.environment}`
+- `${var.project_name}-connections-${var.environment}`
+
+### 4. IAM, CloudWatch & Monitoring (✓ Complete)
+Updated IAM policy names to include environment variable:
+- `eventbridge_policy` → `eventbridge_policy_${var.environment}`
+- `lambda_policy` → `lambda_policy_${var.environment}`
+- `sfn_policy` → `sfn_policy_${var.environment}`
+
+Note: IAM roles and EventBridge rules already included environment variables.
+
+### 5. Additional Changes
+- Removed duplicate `updated_lambda.tf` file that was causing conflicts
+
+## Files Modified
+1. `/main/lambda.tf` - Updated Lambda function names
+2. `/main/s3.tf` - Updated S3 bucket names and KMS alias
+3. `/main/iam.tf` - Updated IAM policy names
+4. Removed `/main/updated_lambda.tf` - Duplicate file
+
+## Next Steps
+1. Test deployment in development workspace
+2. Verify all resources are created with environment-specific names
+3. Test deployment in production workspace
+4. Confirm no naming conflicts exist between environments
+5. Update CI/CD pipelines if necessary to reference new resource names

--- a/main/iam.tf
+++ b/main/iam.tf
@@ -21,7 +21,7 @@ resource "aws_iam_role" "eventbridge_role" {
 }
 
 resource "aws_iam_role_policy" "eventbridge_policy" {
-  name = "eventbridge_policy"
+  name = "eventbridge_policy_${var.environment}"
   role = aws_iam_role.eventbridge_role.id
   policy = jsonencode({
     Version = "2012-10-17"
@@ -66,7 +66,7 @@ resource "aws_iam_role" "lambda_role" {
 }
 
 resource "aws_iam_role_policy" "lambda_policy" {
-  name = "lambda_policy"
+  name = "lambda_policy_${var.environment}"
   role = aws_iam_role.lambda_role.id
 
   policy = jsonencode({
@@ -143,7 +143,7 @@ resource "aws_iam_role" "sfn_role" {
 }
 
 resource "aws_iam_role_policy" "sfn_policy" {
-  name = "sfn_policy"
+  name = "sfn_policy_${var.environment}"
   role = aws_iam_role.sfn_role.id
   policy = jsonencode({
     Version = "2012-10-17"

--- a/main/lambda.tf
+++ b/main/lambda.tf
@@ -19,7 +19,7 @@ locals {
 module "todoist_lambda" {
   source = "./modules/lambda_function"
 
-  function_name    = "todoist_lambda"
+  function_name    = "todoist_lambda_${var.environment}"
   description      = "Lambda function to get incomplete tasks from Todoist"
   handler          = "getTodoist.lambda_handler"
   runtime          = "python3.12"
@@ -51,7 +51,7 @@ module "todoist_lambda" {
 module "chatgpt_lambda" {
   source = "./modules/lambda_function"
 
-  function_name    = "ChatGPT_lambda"
+  function_name    = "ChatGPT_lambda_${var.environment}"
   description      = "Lambda function to process tasks with ChatGPT"
   handler          = "putChatGPT.lambda_handler"
   runtime          = "python3.12"
@@ -83,7 +83,7 @@ module "chatgpt_lambda" {
 module "notion_lambda" {
   source = "./modules/lambda_function"
 
-  function_name    = "notion_lambda"
+  function_name    = "notion_lambda_${var.environment}"
   description      = "Lambda function to create pages in Notion"
   handler          = "putNotion.lambda_handler"
   runtime          = "python3.12"
@@ -115,7 +115,7 @@ module "notion_lambda" {
 module "put_todoist_lambda" {
   source = "./modules/lambda_function"
 
-  function_name    = "put_todoist_lambda"
+  function_name    = "put_todoist_lambda_${var.environment}"
   description      = "Lambda function to update tasks in Todoist"
   handler          = "putTodoist.lambda_handler"
   runtime          = "python3.12"
@@ -148,7 +148,7 @@ module "put_todoist_lambda" {
 module "get_visualization_data" {
   source = "./modules/lambda_function"
 
-  function_name    = "get_visualization_data"
+  function_name    = "get_visualization_data_${var.environment}"
   description      = "Lambda function to retrieve visualization data from S3"
   handler          = "getVisualizationData.lambda_handler"
   runtime          = "python3.12"
@@ -185,7 +185,7 @@ module "get_visualization_data" {
 module "put_visualization_data" {
   source = "./modules/lambda_function"
 
-  function_name    = "put_visualization_data"
+  function_name    = "put_visualization_data_${var.environment}"
   description      = "Lambda function to store visualization data in S3"
   handler          = "putVisualizationData.lambda_handler"
   runtime          = "python3.12"

--- a/main/s3.tf
+++ b/main/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "wyatt-datalake-35315550" {
-  bucket = "step-function-bucket-35315550"
+  bucket = "${var.project_name}-datalake-${var.environment}-35315550"
 
   # Block public access
 }
@@ -61,7 +61,7 @@ resource "aws_kms_key" "s3_key" {
 
 # Add a human-readable alias for the KMS key
 resource "aws_kms_alias" "s3_key_alias" {
-  name          = "alias/${var.project_name}-s3-key"
+  name          = "alias/${var.project_name}-s3-key-${var.environment}"
   target_key_id = aws_kms_key.s3_key.key_id
 }
 
@@ -86,7 +86,7 @@ module "visualization_data_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> 3.0"
 
-  bucket = "wyatt-visualization-data-${random_id.bucket_suffix.hex}"
+  bucket = "${var.project_name}-visualization-data-${var.environment}-${random_id.bucket_suffix.hex}"
 
   # Block public access when using Cognito + API Gateway
   block_public_acls       = true


### PR DESCRIPTION
## Summary
- Implements proper resource naming strategy to fix workspace conflicts between dev and prod environments
- Updates all Terraform resources to include environment variables in their names

## Changes Made

### 1. Lambda Functions
- Updated all Lambda function names to include `${var.environment}` suffix
- Functions now follow pattern: `function_name_${var.environment}`

### 2. S3 Buckets  
- Added environment variable to bucket names
- Updated KMS alias to include environment

### 3. IAM Resources
- Updated IAM policy names to include environment suffix
- IAM roles already had environment variables

### 4. DynamoDB Tables
- No changes needed - already had proper naming

### 5. CloudWatch & Monitoring
- Resources already properly named with environment variables

## Documentation
- Created comprehensive change summary in `WORKSPACE_NAMING_CHANGES.md`
- Addresses issues outlined in `WORKSPACE_NAMING_FIX.md`

## Testing
- Terraform validate passes
- Configuration is ready for deployment testing in both dev and prod workspaces

## Test plan
[ ] Deploy to dev workspace and verify resources are created with `-dev` suffix
[ ] Deploy to prod workspace and verify resources are created with `-prod` suffix
[ ] Confirm no naming conflicts exist between environments
[ ] Verify existing functionality still works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)