### PR TITLE
Fix API Gateway CloudWatch log group naming conflict

### DIFF
--- a/main/API_GATEWAY_NAMING_FIX.md
+++ b/main/API_GATEWAY_NAMING_FIX.md
@@ -1,0 +1,19 @@
+# API Gateway Naming Fix
+
+## Problem
+The API Gateway CloudWatch log group was using a static name `/aws/apigateway/dashboard-api` without including the environment variable. This causes conflicts when deploying to both dev and prod workspaces.
+
+## Solution
+Updated the API Gateway name to include both project name and environment variables:
+- Before: `dashboard-api`
+- After: `${var.project_name}-dashboard-api-${var.environment}`
+
+## Result
+The CloudWatch log group will now be created with environment-specific naming:
+- Dev: `/aws/apigateway/wyatt-dashboard-api-dev`
+- Prod: `/aws/apigateway/wyatt-dashboard-api-prod`
+
+This prevents resource naming conflicts between environments and ensures proper log separation.
+
+## Files Modified
+- `/main/api_gateway.tf` - Updated API Gateway name to include environment variables

--- a/main/api_gateway.tf
+++ b/main/api_gateway.tf
@@ -1,7 +1,7 @@
 module "api_gateway" {
   source = "./modules/api_gateway"
 
-  api_name        = "dashboard-api"
+  api_name        = "${var.project_name}-dashboard-api-${var.environment}"
   api_description = "API for D3 Dashboard visualization data"
 
   # For production, use static CORS. For dev, use dynamic CORS to handle Vercel previews


### PR DESCRIPTION
## Summary
- Fixes CloudWatch log group naming conflict for API Gateway between dev/prod environments
- Adds environment suffix to API Gateway name

## Problem
The API Gateway CloudWatch log group was using a static name `/aws/apigateway/dashboard-api` without including the environment variable. This causes conflicts when deploying to both dev and prod workspaces.

## Solution
Updated the API Gateway name to include both project name and environment variables:
- Before: `dashboard-api`
- After: `${var.project_name}-dashboard-api-${var.environment}`

## Result
The CloudWatch log group will now be created with environment-specific naming:
- Dev: `/aws/apigateway/wyatt-dashboard-api-dev`
- Prod: `/aws/apigateway/wyatt-dashboard-api-prod`

This prevents resource naming conflicts between environments and ensures proper log separation.

## Test plan
[ ] Deploy to dev workspace and verify API Gateway CloudWatch log group is created as `/aws/apigateway/wyatt-dashboard-api-dev`
[ ] Deploy to prod workspace and verify API Gateway CloudWatch log group is created as `/aws/apigateway/wyatt-dashboard-api-prod`
[ ] Confirm no naming conflicts exist between environments
[ ] Verify API logs are properly separated by environment

🤖 Generated with [Claude Code](https://claude.ai/code)