### PR TITLE
fix: Update AWS region from us-east-1 to us-east-2 in GitHub Actions

### DIFF
--- a/.github/workflows/deploy-with-ssm.yml
+++ b/.github/workflows/deploy-with-ssm.yml
@@ -17,7 +17,7 @@ on:
         - prod
 
 env:
-  AWS_REGION: us-east-1
+  AWS_REGION: us-east-2
 
 jobs:
   deploy:
@@ -41,7 +41,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-        role-session-name: GitHubActions
+        role-session-name: GitHubActionsDeployment
         aws-region: ${{ env.AWS_REGION }}
         # Add audience explicitly for China regions or other non-default partitions
         audience: sts.amazonaws.com

--- a/docs/github-actions-aws-oidc-setup.md
+++ b/docs/github-actions-aws-oidc-setup.md
@@ -103,8 +103,8 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-        role-session-name: GitHubActions
-        aws-region: us-east-1
+        role-session-name: GitHubActionsDeployment
+        aws-region: us-east-2
         audience: sts.amazonaws.com
 ```
 


### PR DESCRIPTION
## Summary
This PR fixes the AWS region configuration in the GitHub Actions workflow to match the project's Terraform configuration.

## Problem
The GitHub Actions workflow was using `us-east-1` as the AWS region, but the project's Terraform configuration uses `us-east-2` as the default region across all environments.

## Investigation
After reviewing the configuration files:
- `main/variables.tf`: Default AWS region is `us-east-2`
- `main/environments/dev.tfvars`: AWS region is `us-east-2`
- `main/environments/prod.tfvars`: AWS region is `us-east-2`

The mismatch in regions could be contributing to the credentials loading error.

## Changes
- Updated `AWS_REGION` environment variable from `us-east-1` to `us-east-2`
- Updated documentation to reflect the correct region
- Changed role session name from `GitHubActions` to `GitHubActionsDeployment` (avoiding the potentially problematic name)

## Testing
After this change is deployed, the workflow should:
1. Use the correct AWS region that matches the Terraform configuration
2. Potentially resolve credential loading issues if they were region-related
3. Ensure consistency across the entire deployment pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)