### PR TITLE
fix: Add missing Terraform Cloud workspace configuration

### DIFF
--- a/main/backend.tf
+++ b/main/backend.tf
@@ -2,16 +2,18 @@ terraform {
   cloud {
     organization = "wyatt-personal-aws"
 
-    # Workspace configuration
+    # Workspace configuration using tags strategy
+    # This allows multiple workspaces to be managed under the same configuration
+    workspaces {
+      tags = ["wyatt-personal-aws"]
+    }
+
     # The actual workspace is selected by:
     # 1. TF_WORKSPACE environment variable (set by GitHub Actions)
     # 2. terraform workspace select command (for local development)
     #
     # Valid workspaces:
-    # - wyatt-personal-aws-dev
-    # - wyatt-personal-aws-prod
-    #
-    # NOTE: While we use tag-based selection here for flexibility,
-    # the CI/CD pipeline explicitly sets the workspace name
+    # - wyatt-personal-aws-dev (tagged with "wyatt-personal-aws")
+    # - wyatt-personal-aws-prod (tagged with "wyatt-personal-aws")
   }
 }


### PR DESCRIPTION
## Summary
- Fix Terraform Cloud workspace configuration error preventing SSM workflow from initializing
- Add required workspaces block with tags strategy to backend.tf
- Resolve "Invalid workspaces configuration" error in GitHub Actions

## Key Changes
- Add `workspaces` block with `tags = ["wyatt-personal-aws"]` to backend.tf
- Use tags strategy for flexible workspace management across dev/prod
- Maintain compatibility with existing `TF_WORKSPACE` environment variable usage
- Update documentation explaining workspace tagging requirements

## Error Fixed
```
Error: Invalid workspaces configuration

Missing workspace mapping strategy. Either workspace "tags" or "name" is
required.
```

## Test Plan
- [x] Verify Terraform configuration syntax is valid
- [x] Confirm pre-commit hooks pass
- [ ] Test terraform init succeeds in SSM workflow
- [ ] Validate workspace selection works with TF_WORKSPACE variable

## Impact
This fix is essential for the SSM parameters workflow to successfully initialize Terraform and access the remote state. Without this configuration, terraform init fails immediately.

🤖 Generated with [Claude Code](https://claude.ai/code)