### PR TITLE
fix: Remove conflicting Terraform Cloud workspace configuration

### DIFF
--- a/main/backend.tf
+++ b/main/backend.tf
@@ -2,18 +2,16 @@ terraform {
   cloud {
     organization = "wyatt-personal-aws"
 
-    # Workspace configuration using tags strategy
-    # This allows multiple workspaces to be managed under the same configuration
-    workspaces {
-      tags = ["wyatt-personal-aws"]
-    }
+    # Workspace configuration using name strategy
+    # This allows explicit workspace selection via TF_WORKSPACE environment variable
+    # No workspaces block needed - workspace is selected dynamically via TF_WORKSPACE
 
     # The actual workspace is selected by:
     # 1. TF_WORKSPACE environment variable (set by GitHub Actions)
     # 2. terraform workspace select command (for local development)
     #
     # Valid workspaces:
-    # - wyatt-personal-aws-dev (tagged with "wyatt-personal-aws")
-    # - wyatt-personal-aws-prod (tagged with "wyatt-personal-aws")
+    # - wyatt-personal-aws-dev
+    # - wyatt-personal-aws-prod
   }
 }


### PR DESCRIPTION
## Summary
- Fix Terraform Cloud workspace configuration conflict preventing SSM workflow initialization
- Remove conflicting workspaces block with tags strategy from backend.tf
- Resolve "Only one of workspace 'tags' or 'name' is allowed" error

## Root Cause Analysis
The backend.tf was mixing two incompatible Terraform Cloud workspace strategies:
1. **Tags strategy** (`tags = ["wyatt-personal-aws"]`) in backend.tf
2. **Explicit workspace selection** via `TF_WORKSPACE` environment variable in workflows

These strategies are mutually exclusive in Terraform Cloud configuration.

## Solution
- Remove the `workspaces` block with tags strategy from backend.tf
- Rely exclusively on `TF_WORKSPACE` environment variable for workspace selection
- This aligns the configuration with how both workflows already operate

## Key Changes
- Removed conflicting `workspaces { tags = ["wyatt-personal-aws"] }` block
- Updated documentation to clarify workspace selection via TF_WORKSPACE
- Tested successfully with both `wyatt-personal-aws-dev` and `wyatt-personal-aws-prod` workspaces

## Workflow Compatibility
✅ **terraform_apply.yml**: Already sets `TF_WORKSPACE` as environment variable  
✅ **ssm_params.yml**: Already sets `TF_WORKSPACE` dynamically in workflow steps  
✅ **Both workflows**: Will continue working exactly as before, but without conflicts

## Test Results
```bash
# Successfully tested workspace selection
TF_WORKSPACE=wyatt-personal-aws-dev terraform init    # ✅ Works
TF_WORKSPACE=wyatt-personal-aws-prod terraform init   # ✅ Works
```

## Impact
This fix is essential for the SSM parameters workflow to successfully initialize Terraform and resolve the workspace configuration conflict that was causing init failures.

🤖 Generated with [Claude Code](https://claude.ai/code)