### PR TITLE
fix: Remove workspaces block from backend.tf to resolve Terraform init error

### DIFF
--- a/main/backend.tf
+++ b/main/backend.tf
@@ -11,11 +11,8 @@ terraform {
     # - wyatt-personal-aws-dev
     # - wyatt-personal-aws-prod
     #
-    # NOTE: While we use tag-based selection here for flexibility,
-    # the CI/CD pipeline explicitly sets the workspace name
-
-    workspaces {
-      tags = ["wyatt-personal-aws"]
-    }
+    # NOTE: No workspaces block is needed here because workspace selection
+    # is handled via the TF_WORKSPACE environment variable, which is set
+    # by the CI/CD pipeline and can be set locally for development.
   }
 }


### PR DESCRIPTION
## Summary
Fixes the Terraform init error: `Only one of workspace 'tags' or 'name' is allowed`

## Problem
The merge from PR #203 reintroduced the `workspaces { tags = [...] }` block in backend.tf, which conflicts with the TF_WORKSPACE environment variable strategy used by all GitHub Actions workflows.

## Solution
Remove the workspaces block from backend.tf, allowing Terraform Cloud to use the workspace name strategy via the TF_WORKSPACE environment variable.

## Analysis
Reviewed all GitHub Actions workflows and confirmed they consistently use TF_WORKSPACE:
- `terraform_apply.yml`: Sets TF_WORKSPACE based on branch (main→prod, dev→dev)
- `terraform_plan.yml`: Sets TF_WORKSPACE based on branch
- `ssm_params.yml`: Sets TF_WORKSPACE based on environment
- `drift-detection.yml`: Sets TF_WORKSPACE explicitly for each environment

## History
This issue has occurred before:
- PR #196 added the workspaces block with tags
- PR #197 removed it due to this same conflict
- PR #203 (OIDC provider fix) inadvertently reintroduced it during merge

## Test plan
- [ ] Verify `terraform init` runs successfully with TF_WORKSPACE set
- [ ] Confirm GitHub Actions workflows pass
- [ ] Test both dev and prod workspace initialization

🤖 Generated with [Claude Code](https://claude.ai/code)