### PR TITLE
fix(terraform): Add KMS permissions for Athena service access

### DIFF
--- a/main/athena.tf
+++ b/main/athena.tf
@@ -110,6 +110,39 @@ resource "aws_iam_policy" "athena_access" {
           aws_s3_bucket.athena_results.arn,
           "${aws_s3_bucket.athena_results.arn}/*"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:GenerateDataKey",
+          "kms:CreateGrant",
+          "kms:DescribeKey"
+        ]
+        Resource = [
+          aws_kms_key.s3_key.arn
+        ]
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = [
+              "s3.${var.aws_region}.amazonaws.com",
+              "athena.${var.aws_region}.amazonaws.com"
+            ]
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "glue:GetDatabase",
+          "glue:GetTable",
+          "glue:GetPartitions"
+        ]
+        Resource = [
+          "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:catalog",
+          "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:database/${aws_athena_database.forecast_db.name}",
+          "arn:aws:glue:${var.aws_region}:${data.aws_caller_identity.current.account_id}:table/${aws_athena_database.forecast_db.name}/*"
+        ]
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Fix Athena 500 error by adding proper KMS permissions
- Update KMS key policy to grant access to Athena service
- Add Lambda role permissions for KMS operations

## Changes
- Updated KMS key policy in `s3.tf` to include:
  - Athena service principal with decrypt and generate data key permissions
  - Lambda role with KMS permissions via S3 and Athena services
  - S3 service principal for bucket encryption operations
- Updated IAM policy in `athena.tf` to include:
  - KMS decrypt permissions for Lambda role
  - AWS Glue permissions for Athena data catalog access

## Test Plan
- [ ] Deploy to dev environment
- [ ] Test Athena queries on encrypted S3 buckets
- [ ] Verify Lambda function can execute Athena queries
- [ ] Confirm no KMS access errors in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.ai/code)