### PR TITLE
fix: Resolve GitHub Actions OIDC role mismatch and CloudWatch Log Group conflicts (Task #6)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
           - --args=--severity=HIGH,CRITICAL
           - --args=--skip-dirs=.terraform
           - --args=--skip-dirs="**/.terraform/**"
-          - --args=--tf-vars=/workspaces/wyatt-personal-aws/main/environments/dev.tfvars
+          - --args=--tf-vars=main/environments/dev.tfvars
       - id: terraform_docs # auto-fills README tables
         stages: [pre-push] # heavy ⟶ run only on push
 

--- a/main/github_actions_oidc.tf
+++ b/main/github_actions_oidc.tf
@@ -41,8 +41,10 @@ locals {
 }
 
 # IAM Role for GitHub Actions with necessary permissions
+# Only create in dev environment to avoid conflicts
 resource "aws_iam_role" "github_actions" {
-  name = "github-actions-oidc-role-${var.environment}"
+  count = var.environment == "dev" ? 1 : 0
+  name  = "github-actions-role"
 
   # Trust policy that allows GitHub Actions to assume this role via OIDC
   assume_role_policy = jsonencode({
@@ -77,8 +79,10 @@ resource "aws_iam_role" "github_actions" {
 }
 
 # Permissions policy for GitHub Actions to interact with AWS resources
+# Only create in dev environment to avoid conflicts
 resource "aws_iam_policy" "github_actions_permissions" {
-  name        = "github-actions-permissions-${var.environment}"
+  count       = var.environment == "dev" ? 1 : 0
+  name        = "github-actions-permissions"
   description = "Permissions for GitHub Actions to deploy infrastructure and applications"
 
   policy = jsonencode({
@@ -152,14 +156,15 @@ resource "aws_iam_policy" "github_actions_permissions" {
 
 # Attach the permissions policy to the GitHub Actions role
 resource "aws_iam_role_policy_attachment" "github_actions_permissions" {
-  role       = aws_iam_role.github_actions.name
-  policy_arn = aws_iam_policy.github_actions_permissions.arn
+  count      = var.environment == "dev" ? 1 : 0
+  role       = aws_iam_role.github_actions[0].name
+  policy_arn = aws_iam_policy.github_actions_permissions[0].arn
 }
 
 # Add outputs to make it easy to use the role ARN in GitHub secrets
 output "github_actions_role_arn" {
   description = "ARN of the IAM role for GitHub Actions OIDC authentication"
-  value       = aws_iam_role.github_actions.arn
+  value       = var.environment == "dev" ? aws_iam_role.github_actions[0].arn : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/github-actions-role"
 }
 
 output "github_actions_oidc_provider_arn" {

--- a/main/lambda_forecast_sync.tf
+++ b/main/lambda_forecast_sync.tf
@@ -17,7 +17,7 @@ module "forecast_sync_lambda" {
   memory_size   = 1024
   zip_file      = local.forecast_sync_lambda_zip_path
 
-  create_log_group = false
+  create_log_group = true
 
   environment_variables = {
     ATHENA_DB_NAME           = "default"
@@ -131,16 +131,16 @@ module "forecast_sync_lambda" {
   }
 }
 
-# CloudWatch Log Group for Lambda
-resource "aws_cloudwatch_log_group" "forecast_sync" {
-  name              = "/aws/lambda/forecast-sync-${var.environment}"
-  retention_in_days = 30
-
-  tags = {
-    Component = "Data Sync"
-    Function  = "Forecast Sync Logs"
-  }
-}
+# CloudWatch Log Group for Lambda - removed as lambda module will create it
+# resource "aws_cloudwatch_log_group" "forecast_sync" {
+#   name              = "/aws/lambda/forecast-sync-${var.environment}"
+#   retention_in_days = 30
+#
+#   tags = {
+#     Component = "Data Sync"
+#     Function  = "Forecast Sync Logs"
+#   }
+# }
 
 # Lambda permission for S3 to invoke the function
 resource "aws_lambda_permission" "s3_invoke" {


### PR DESCRIPTION
This PR resolves Task #6 by fixing GitHub Actions OIDC authentication error and CloudWatch Log Group creation conflicts.

Changes:
- Fix OIDC role name mismatch from github-actions-oidc-role-env to github-actions-role
- Make GitHub Actions IAM resources conditional for dev environment only
- Remove duplicate CloudWatch Log Group resource for forecast-sync lambda
- Enable create_log_group in lambda module
- Fix trivy terraform hook to use relative path for tfvars

Impact:
- Resolves 'Not authorized to perform sts:AssumeRoleWithWebIdentity' error
- Eliminates CloudWatch Log Group ResourceAlreadyExistsException
- Enables successful GitHub Actions workflows
- Fixes pre-commit trivy hook path issues