### PR TITLE
fix: Add forecast sync lambda to CI/CD pipeline and resolve CloudWatch log group conflicts (Task #7)

### DIFF
--- a/.github/workflows/deployment_package_zip.yml
+++ b/.github/workflows/deployment_package_zip.yml
@@ -52,6 +52,24 @@ jobs:
                 # Copy to main directory for Terraform
                 cp athena-lambda.zip ../../../main/
 
+            - name: Build Python Forecast Sync Lambda package
+              run: |
+                # Create forecast sync package directory
+                mkdir -p deploy/forecast_sync
+
+                # Copy forecast sync Python files
+                cp src/lambda/forecast_sync/*.py deploy/forecast_sync/
+
+                # Install forecast sync dependencies
+                pip install -r src/lambda/forecast_sync/requirements.txt -t deploy/forecast_sync/
+
+                # Create ZIP package
+                cd deploy/forecast_sync
+                zip -r9 forecast-sync-lambda.zip . -x "*.git*" -x "*.pyc" -x "__pycache__/*"
+
+                # Copy to main directory for Terraform
+                cp forecast-sync-lambda.zip ../../main/
+
             - name: Zip Python dependencies
               run: zip -r9 ./deployment_package.zip ./
               working-directory: ./deploy
@@ -67,3 +85,9 @@ jobs:
               with:
                   name: athena-lambda-package
                   path: ./main/athena-lambda.zip
+
+            - name: Upload Forecast Sync Lambda package
+              uses: actions/upload-artifact@v4
+              with:
+                  name: forecast-sync-lambda-package
+                  path: ./main/forecast-sync-lambda.zip

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -44,6 +44,12 @@ jobs:
           name: athena-lambda-package
           path: ./main/
 
+      - name: Download Forecast Sync Lambda package
+        uses: actions/download-artifact@v4
+        with:
+          name: forecast-sync-lambda-package
+          path: ./main/
+
       - name: Upload Configuration
         uses: hashicorp/tfc-workflows-github/actions/upload-configuration@v1.0.0
         id: apply-upload

--- a/.github/workflows/terraform_plan.yml
+++ b/.github/workflows/terraform_plan.yml
@@ -42,6 +42,12 @@ jobs:
           name: athena-lambda-package
           path: ./main/
 
+      - name: Download Forecast Sync Lambda package
+        uses: actions/download-artifact@v4
+        with:
+          name: forecast-sync-lambda-package
+          path: ./main/
+
       - name: Debug - List Files
         run: |
           echo "Files in main directory:"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@ repos:
           - --args=--severity=HIGH,CRITICAL
           - --args=--skip-dirs=.terraform
           - --args=--skip-dirs="**/.terraform/**"
-          - --args=--tf-vars=main/environments/dev.tfvars
       - id: terraform_docs # auto-fills README tables
         stages: [pre-push] # heavy ⟶ run only on push
 

--- a/main/modules/lambda_function/main.tf
+++ b/main/modules/lambda_function/main.tf
@@ -32,18 +32,10 @@ module "lambda_function" {
   # Add VPC policy statements if Lambda is deployed in VPC
   attach_network_policy = var.vpc_subnet_ids != null ? true : false
 
-  tags = merge(var.tags, {
-    Environment = var.environment
-  })
-}
+  # CloudWatch Logs configuration
+  create_cloudwatch_log_group       = var.create_log_group
+  cloudwatch_logs_retention_in_days = var.log_retention_days
 
-# Handle CloudWatch log groups using AWS provider directly
-resource "aws_cloudwatch_log_group" "lambda" {
-  # Only create if create_log_group is true
-  count = var.create_log_group ? 1 : 0
-
-  name              = "/aws/lambda/${var.function_name}"
-  retention_in_days = var.log_retention_days
   tags = merge(var.tags, {
     Environment = var.environment
   })


### PR DESCRIPTION
This PR resolves Task #7 by fixing the CI/CD pipeline to build the forecast sync lambda and resolving CloudWatch log group conflicts.

## Changes

### CI/CD Pipeline Fixes
- **Added forecast sync lambda build**: Updated deployment_package_zip.yml to build forecast-sync-lambda.zip
- **Added artifact downloads**: Updated terraform_apply.yml and terraform_plan.yml to download forecast sync lambda artifacts
- **Fixed trivy configuration**: Removed problematic tfvars path argument that was causing failures

### CloudWatch Log Group Conflict Resolution
- **Removed duplicate log group resource**: Fixed conflict between terraform-aws-modules/lambda and custom log group creation
- **Updated lambda module configuration**: Use built-in CloudWatch log group creation with proper parameters

## Impact

- ✅ Resolves missing forecast-sync-lambda.zip file error during terraform apply
- ✅ Eliminates ResourceAlreadyExistsException for CloudWatch Log Group conflicts  
- ✅ Enables CI/CD pipeline to build and deploy forecast sync lambda properly
- ✅ Fixes pre-commit trivy hook failures

## Testing

- [x] Pre-commit hooks pass without trivy failures
- [x] Terraform formatting applied successfully
- [ ] Will test lambda ZIP creation and deployment after merge

🤖 Generated with [Claude Code](https://claude.ai/code)