### PR TITLE
fix: Remove AWS_REGION from Lambda environment variables

### DIFF
--- a/main/lambda_forecast_sync.tf
+++ b/main/lambda_forecast_sync.tf
@@ -25,7 +25,6 @@ module "forecast_sync_lambda" {
     FORECAST_TABLE_NAME      = "forecast"
     SSM_NEON_API_KEY_PATH    = "/forecast-sync/${var.environment}/neon-api-key"
     SSM_NEON_PROJECT_ID_PATH = "/forecast-sync/${var.environment}/neon-project-id"
-    AWS_REGION               = var.aws_region
     BATCH_SIZE               = "10000"
     ENVIRONMENT              = var.environment
   }


### PR DESCRIPTION
This PR fixes the Lambda creation error caused by using AWS_REGION as an environment variable.

## Issue
AWS Lambda was failing to create the forecast-sync-dev function with error:


## Root Cause
AWS_REGION is a reserved environment variable in AWS Lambda and cannot be set manually through Terraform.

## Solution
- Removed AWS_REGION from the environment_variables configuration in lambda_forecast_sync.tf
- AWS Lambda automatically provides AWS_REGION in the runtime environment
- The Lambda code already has a fallback value (us-east-2) so it will continue to work correctly

## Impact
- ✅ Fixes Lambda function creation error
- ✅ Lambda code continues to work correctly with AWS-provided AWS_REGION
- ✅ Maintains backward compatibility with existing fallback logic

🤖 Generated with [Claude Code](https://claude.ai/code)