### PR TITLE
fix: Add forecast-sync SSM parameter permissions to GitHub Actions role

### DIFF
--- a/main/github_actions_oidc.tf
+++ b/main/github_actions_oidc.tf
@@ -127,7 +127,10 @@ resource "aws_iam_policy" "github_actions_permissions" {
           "ssm:PutParameter",
           "ssm:ListParameters"
         ]
-        Resource = "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/wyatt-personal-aws-*"
+        Resource = [
+          "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/wyatt-personal-aws-*",
+          "arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:parameter/forecast-sync/*"
+        ]
       },
       # Terraform State Access (if using S3 backend)
       {


### PR DESCRIPTION
This PR fixes the AccessDeniedException error when GitHub Actions tries to store Neon configuration in SSM Parameter Store.

## Issue
GitHub Actions workflow was failing with:


## Root Cause
The GitHub Actions IAM role had SSM permissions only for  parameters, but the forecast sync lambda needs to store configuration under  parameters.

## Solution
Extended the SSM parameter permissions in the GitHub Actions role to include both:
-  (existing pattern)
-  (new pattern for forecast sync lambda)

## Impact
- ✅ Fixes GitHub Actions SSM parameter creation failures
- ✅ Enables storage of Neon API keys and project IDs for forecast sync lambda
- ✅ Maintains existing permissions for other SSM parameters
- ✅ Follows principle of least privilege (only specific parameter paths)

## Actions
-  - Read parameters
-  - Create/update parameters  
-  - List available parameters

🤖 Generated with [Claude Code](https://claude.ai/code)