### PR TITLE
fix: Separate SSM parameter creation and tagging to resolve AWS validation error

### DIFF
--- a/.github/workflows/ssm_params.yml
+++ b/.github/workflows/ssm_params.yml
@@ -216,25 +216,37 @@ jobs:
         run: |
           echo "Storing Neon configuration in SSM for ${ENVIRONMENT} environment..."
 
-          # Store API key as SecureString
+          # Store API key as SecureString (create/update parameter first)
           aws ssm put-parameter \
             --name "/forecast-sync/${ENVIRONMENT}/neon-api-key" \
             --value "${{ secrets.NEON_API_KEY }}" \
             --type "SecureString" \
             --overwrite \
             --description "Neon API key for forecast sync Lambda" \
-            --tags "Key=Environment,Value=${ENVIRONMENT}" "Key=Service,Value=forecast-sync" \
             || { echo "Failed to store Neon API key"; exit 1; }
 
-          # Store project ID as regular String
+          # Add tags to the API key parameter
+          aws ssm add-tags-to-resource \
+            --resource-type "Parameter" \
+            --resource-id "/forecast-sync/${ENVIRONMENT}/neon-api-key" \
+            --tags "Key=Environment,Value=${ENVIRONMENT}" "Key=Service,Value=forecast-sync" \
+            || { echo "Failed to tag Neon API key parameter"; exit 1; }
+
+          # Store project ID as regular String (create/update parameter first)
           aws ssm put-parameter \
             --name "/forecast-sync/${ENVIRONMENT}/neon-project-id" \
             --value "${{ secrets.NEON_PROJECT_ID }}" \
             --type "String" \
             --overwrite \
             --description "Neon project ID for forecast sync Lambda" \
-            --tags "Key=Environment,Value=${ENVIRONMENT}" "Key=Service,Value=forecast-sync" \
             || { echo "Failed to store Neon project ID"; exit 1; }
+
+          # Add tags to the project ID parameter
+          aws ssm add-tags-to-resource \
+            --resource-type "Parameter" \
+            --resource-id "/forecast-sync/${ENVIRONMENT}/neon-project-id" \
+            --tags "Key=Environment,Value=${ENVIRONMENT}" "Key=Service,Value=forecast-sync" \
+            || { echo "Failed to tag Neon project ID parameter"; exit 1; }
 
           echo "✅ Successfully stored Neon configuration in SSM for ${ENVIRONMENT} environment"
 


### PR DESCRIPTION
## Summary

- Split SSM parameter creation and tagging into separate commands to fix AWS validation error
- AWS SSM doesn't allow `--tags` and `--overwrite` flags to be used together in the same command
- Now uses two-step process: create/update parameter first, then add tags separately

## Problem Fixed

The combined SSM workflow was failing with:
```
ValidationException: Invalid request: tags and overwrite can't be used together. To create a parameter with tags, please remove overwrite flag. To update tags for an existing parameter, please use AddTagsToResource or RemoveTagsFromResource.
```

## Solution

Changed from:
```bash
aws ssm put-parameter --name "..." --value "..." --overwrite --tags "..."
```

To:
```bash
aws ssm put-parameter --name "..." --value "..." --overwrite
aws ssm add-tags-to-resource --resource-type "Parameter" --resource-id "..." --tags "..."
```

## Test Plan

- [x] Workflow validates YAML syntax
- [ ] Test the workflow on dev environment to ensure SSM parameters are created and tagged correctly
- [ ] Verify that existing parameters are properly updated without losing existing tags

🤖 Generated with [Claude Code](https://claude.ai/code)