### PR TITLE
fix: Add ssm:GetParameters permission required for AddTagsToResource

### DIFF
--- a/main/github_actions_oidc.tf
+++ b/main/github_actions_oidc.tf
@@ -124,6 +124,7 @@ resource "aws_iam_policy" "github_actions_permissions" {
         Effect = "Allow"
         Action = [
           "ssm:GetParameter",
+          "ssm:GetParameters",
           "ssm:PutParameter",
           "ssm:ListParameters",
           "ssm:DescribeParameters",


### PR DESCRIPTION
## Summary

- Add missing `ssm:GetParameters` permission required for `AddTagsToResource` operation
- Fixes AccessDeniedException when tagging SSM parameters in the combined workflow

## Problem Fixed

The SSM workflow was failing with:
```
AccessDeniedException: User is not authorized to perform: ssm:GetParameters on resource: arn:aws:ssm:us-east-2:***:parameter/forecast-sync/dev/neon-api-key because no identity-based policy allows the ssm:GetParameters action
```

## Root Cause

AWS's `AddTagsToResource` operation internally calls `GetParameters` (plural) to validate that the parameter exists before applying tags. While we had `ssm:GetParameter` (singular), we were missing `ssm:GetParameters` (plural).

## Solution

Added `ssm:GetParameters` to the GitHub Actions IAM policy:

```hcl
Action = [
  "ssm:GetParameter",
  "ssm:GetParameters",        # <- Added this
  "ssm:PutParameter",
  "ssm:ListParameters",
  "ssm:DescribeParameters",
  "ssm:AddTagsToResource"
]
```

## Test Plan

- [x] Terraform validates syntax and policy structure
- [ ] Test the workflow on dev environment to ensure SSM parameters can be tagged successfully
- [ ] Verify that both parameter creation and tagging complete without errors

🤖 Generated with [Claude Code](https://claude.ai/code)