### PR TITLE
fix: Match Vercel build and deploy environments for dev/main branches

### DIFF
--- a/.github/workflows/nextjs-deploy-with-neon.yml
+++ b/.github/workflows/nextjs-deploy-with-neon.yml
@@ -129,7 +129,16 @@ jobs:
       # Step 12: Pull Vercel Environment Information
       - name: Pull Vercel Environment Information
         working-directory: src/frontend/nextjs-app
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          # Determine environment type based on branch
+          CURRENT_BRANCH="${{ steps.branch_name.outputs.current_branch }}"
+          if [ "$CURRENT_BRANCH" = "dev" ] || [ "$CURRENT_BRANCH" = "main" ]; then
+            echo "Pulling production environment information..."
+            vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+          else
+            echo "Pulling preview environment information..."
+            vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+          fi
 
       # Step 13: Build Project
       - name: Build Project Artifacts
@@ -138,23 +147,39 @@ jobs:
           # Pass database URLs during build
           DATABASE_URL: ${{ steps.create_neon_branch.outputs.db_url_with_pooler }}
           DATABASE_URL_UNPOOLED: ${{ steps.create_neon_branch.outputs.db_url }}
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          # Determine build type based on branch
+          CURRENT_BRANCH="${{ steps.branch_name.outputs.current_branch }}"
+          if [ "$CURRENT_BRANCH" = "dev" ] || [ "$CURRENT_BRANCH" = "main" ]; then
+            echo "Building for production deployment..."
+            vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+          else
+            echo "Building for preview deployment..."
+            vercel build --token=${{ secrets.VERCEL_TOKEN }}
+          fi
 
       # Step 14: Create environment variables in Vercel
       - name: Set Vercel Environment Variables
         working-directory: src/frontend/nextjs-app
         run: |
-          echo "Creating environment variables in Vercel for preview..."
+          # Determine environment type based on branch
+          CURRENT_BRANCH="${{ steps.branch_name.outputs.current_branch }}"
+          if [ "$CURRENT_BRANCH" = "dev" ] || [ "$CURRENT_BRANCH" = "main" ]; then
+            echo "✅ Skipping environment variable updates for production deployment"
+            echo "Production database URLs should be configured in Vercel dashboard"
+          else
+            echo "Creating environment variables in Vercel for preview..."
 
-          # Remove existing env vars if they exist (to update them)
-          vercel env rm DATABASE_URL preview --yes --token=${{ secrets.VERCEL_TOKEN }} || true
-          vercel env rm DATABASE_URL_UNPOOLED preview --yes --token=${{ secrets.VERCEL_TOKEN }} || true
+            # Remove existing env vars if they exist (to update them)
+            vercel env rm DATABASE_URL preview --yes --token=${{ secrets.VERCEL_TOKEN }} || true
+            vercel env rm DATABASE_URL_UNPOOLED preview --yes --token=${{ secrets.VERCEL_TOKEN }} || true
 
-          # Add new env vars for preview environment
-          echo "${{ steps.create_neon_branch.outputs.db_url_with_pooler }}" | vercel env add DATABASE_URL preview --token=${{ secrets.VERCEL_TOKEN }}
-          echo "${{ steps.create_neon_branch.outputs.db_url }}" | vercel env add DATABASE_URL_UNPOOLED preview --token=${{ secrets.VERCEL_TOKEN }}
+            # Add new env vars for preview environment
+            echo "${{ steps.create_neon_branch.outputs.db_url_with_pooler }}" | vercel env add DATABASE_URL preview --token=${{ secrets.VERCEL_TOKEN }}
+            echo "${{ steps.create_neon_branch.outputs.db_url }}" | vercel env add DATABASE_URL_UNPOOLED preview --token=${{ secrets.VERCEL_TOKEN }}
 
-          echo "✅ Environment variables created in Vercel"
+            echo "✅ Environment variables created in Vercel for preview"
+          fi
 
       # Step 15: Deploy to Vercel
       - name: Deploy to Vercel


### PR DESCRIPTION
## Summary

This PR fixes the 'prebuilt environment mismatch' error that occurs when deploying dev and main branches to Vercel.

## Problem
The workflow was building with the default 'preview' target but trying to deploy with '--prod' flag, causing an environment mismatch error:
```
Error: The "--prebuilt" option was used with the target environment "production", 
but the prebuilt output found in ".vercel/output" was built with target environment "preview".
```

## Solution
1. **Build phase**: Added logic to use `--prod` flag when building for dev/main branches
2. **Pull phase**: Pull correct environment configuration (production vs preview) based on branch
3. **Environment variables**: Skip database URL updates for production deployments since they should use stable URLs configured in Vercel dashboard

## Changes
- Modified `.github/workflows/nextjs-deploy-with-neon.yml` to:
  - Determine branch type and build/deploy accordingly
  - Use `vercel build --prod` for dev/main branches
  - Use `vercel pull --environment=production` for dev/main branches
  - Skip dynamic database URL updates for production deployments

## Testing
After merging, the next push to dev branch should deploy successfully without the environment mismatch error.