### PR TITLE
fix: Update IAM trust policy to support environment-based OIDC claims

### DIFF
--- a/main/github_actions_oidc.tf
+++ b/main/github_actions_oidc.tf
@@ -61,10 +61,15 @@ resource "aws_iam_role" "github_actions" {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
           }
           StringLike = {
-            "token.actions.githubusercontent.com:sub" = [
-              for branch in local.allowed_branches :
-              "repo:${local.github_org}/${local.github_repo}:ref:refs/heads/${branch}"
-            ]
+            "token.actions.githubusercontent.com:sub" = concat(
+              # Allow branch-based claims
+              [for branch in local.allowed_branches :
+                "repo:${local.github_org}/${local.github_repo}:ref:refs/heads/${branch}"
+              ],
+              # Allow environment-based claims (used by workflows with environment: parameter)
+              ["repo:${local.github_org}/${local.github_repo}:environment:dev",
+              "repo:${local.github_org}/${local.github_repo}:environment:prod"]
+            )
           }
         }
       }


### PR DESCRIPTION
## Summary
Fixes the GitHub Actions OIDC authentication error for the drizzle-migrations workflow.

## Problem
The drizzle-migrations workflow was failing with:
```
Error: Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

## Root Cause
The workflow uses `environment: dev` which causes GitHub to send a different OIDC token subject claim:
- **Expected by IAM trust policy**: `repo:wmjones/wyatt-personal-aws:ref:refs/heads/dev`
- **Actually sent by GitHub**: `repo:wmjones/wyatt-personal-aws:environment:dev`

## Solution
Updated the IAM trust policy to accept both claim formats:
- Branch-based claims (for workflows without environment parameter)
- Environment-based claims (for workflows with environment parameter)

## Test Plan
After merging and applying Terraform:
1. Re-run the failed drizzle-migrations workflow
2. Verify it can successfully assume the IAM role
3. Confirm migrations complete without authentication errors

## CloudTrail Evidence
The CloudTrail logs showed the exact claim being sent:
```json
"principalId": "arn:aws:iam::761551243560:oidc-provider/token.actions.githubusercontent.com:sts.amazonaws.com:repo:wmjones/wyatt-personal-aws:environment:dev"
```

This confirms the environment-based claim format.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>